### PR TITLE
Add metric interface for GR hydro to complete #3

### DIFF
--- a/gr/__init__.py
+++ b/gr/__init__.py
@@ -1,0 +1,8 @@
+"""
+    pyro.gr
+
+    This module contains commonly used classes and routines for implementing a 
+    general-relativistic hydrodynamics solver.
+"""
+
+__all__ = ["metric", "tensor"]

--- a/gr/metric.py
+++ b/gr/metric.py
@@ -1,0 +1,258 @@
+"""
+    metric.py
+
+    Implmentation of a generic 3+1 metric and sample derived classes.  The 
+    base `Metric` class contains the spatial metric, lapse, shift vector, and 
+    extrinsic curvature.  These quantities are represented as rank-two tensors 
+    and three-vectors, whether as single vector/tensors or as a grid of 
+    vectors/tensors.  Additional functionality includes routines for lowering/
+    raising indices of vectors and tensors, and contractions/scalar products.
+
+    Three sample derived metrics are included:
+
+        * Minkowski: Cartesian flat metric.  As this metric does not change in 
+        space, it is not implemented as a grid function.
+
+        * Spherical: Spherical coordinate metric; can be instantiated at one 
+        grid location or over an entire grid.
+
+        * Schwarzschild: Schwarzschild metric in Schwarzschild coordinates, 
+        with appropriate lapse function and vanishing shift vector and 
+        extrinsic curvature; can be instantiated at one grid location or over 
+        an entire grid.
+"""
+
+import numpy as np
+
+from gr.tensor import ThreeVector, Tensor
+
+
+class Metric(object):
+    """Base 3+1 metric object.
+
+    Attributes
+    ----------
+    g : Rank-2 Tensor
+        The spatial metric (covariant components)
+    inv_g : Rank-2 Tensor
+        Inverse spatial metric (contravariant components)
+    det_g : Scalar
+        Determinant of the spatial metric
+
+    alpha : Scalar
+        The lapse function
+    beta : 3-Vector
+        The shift vector
+    K : Rank-2 Tensor
+        The extrinsic curvature
+    """
+
+    def __init__(self, g: Tensor, alpha, beta: ThreeVector, K: Tensor):
+        """Instantiate the metric
+
+        Parameters
+        ----------
+        g : Tensor
+            Covariant spatial metric
+        alpha : Scalar
+            Lapse function
+        beta : ThreeVector
+            Shift vector
+        K : Tensor
+            Extrinsic curvature
+        """
+        # Save the inputs
+        self.g = g
+        self.alpha = alpha
+        self.beta = beta
+        self.K = K
+
+        # Calculate these once
+        self.inv_g = np.linalg.inv(g)
+        self.det_g = np.linalg.det(g)
+
+    def raise_vector(self, A):
+        """Raise the index of a covariant vector.
+
+        Parameters
+        ----------
+        A : ThreeVector
+            Covariant 3-vector
+
+        Returns
+        -------
+        ThreeVector
+            3-Vector with raised components
+        """
+        return self.inv_g.vector_contract(A)
+
+    def lower_vector(self, A):
+        """Lower the index of a contravariant vector.
+
+        Parameters
+        ----------
+        A : ThreeVector
+            Contravariant 3-vector
+
+        Returns
+        -------
+        ThreeVector
+            3-Vector with lowered components
+        """
+        return self.g.vector_contract(A)
+
+    def raise_tensor(self, T, slot=0):
+        """Raise the specified component of a rank-two tensor
+
+        Parameters
+        ----------
+        T : Tensor
+            A rank-two tensor with covariant components to raise
+        slot : int, optional
+            The slot to raise (the default is 0, which corresponds to the first slot)
+
+        Returns
+        -------
+        Tensor
+            Rank-2 tensor with raised components in specified slot.
+        """
+        return self.inv_g.tensor_contract(T, slots=(0, slot))
+
+    def lower_tensor(self, T, slot=0):
+        """Lower the specified component of a rank-two tensor
+
+        Parameters
+        ----------
+        T : Tensor
+            A rank-two tensor with contravariant components to lower
+        slot : int, optional
+            The slot to lower (the default is 0, which corresponds to the first slot)
+
+        Returns
+        -------
+        Tensor
+            Rank-2 tensor with lowered components in specified slot.
+        """
+        return self.g.tensor_contract(T, slots=(0, slot))
+
+    def raise_tensor_all(self, T):
+        """Raise all components of a rank-two tensor
+
+        Parameters
+        ----------
+        T : Tensor
+            A rank-two tensor with covariant components to raise
+
+        Returns
+        -------
+        Tensor
+            Rank-2 tensor with raised components.
+        """
+        return np.einsum("...ik,...jl,...kl->...ij", self.inv_g, self.inv_g, T,
+                         optimize='greedy')
+
+    def lower_tensor_all(self, T):
+        """Lower all components of a rank-two tensor
+
+        Parameters
+        ----------
+        T : Tensor
+            A rank-two tensor with contravariant components to lower
+
+        Returns
+        -------
+        Tensor
+            Rank-2 tensor with lowered components.
+        """
+        return np.einsum("...ik,...jl,...kl->...ij", self.g, self.g, T,
+                         optimize='greedy')
+
+    def scalar_product(self, A, B):
+        """Scalar product of two 3-vectors.
+
+        Parameters
+        ----------
+        A, B : ThreeVector
+            Vectors to contract
+
+        Returns
+        -------
+        Scalar
+            The scalar prodcut of the two provided vectors.
+        """
+        return self.g.contract_with_vectors(A, B)
+
+
+class MinkowskiMetric(Metric):
+    """Minkowski flat metric in Cartesian coordinates"""
+
+    def __init__(self):
+        """Instantiate a non-grid function Minkowski metric."""
+        # Fill spatial metric components
+        g = np.eye(3, dtype=float).view(Tensor)
+
+        # Vanishing shift and extrinsic curvature
+        K = np.zeros_like(g)
+        beta = ThreeVector(0.0, 0.0, 0.0)
+
+        # Required time component of full metric: -alpha**2 dt**2
+        alpha = 1.0
+
+        super().__init__(g, alpha, beta, K)
+
+
+class SphericalMetric(Metric):
+    """Spherical coordinate metric"""
+
+    def __init__(self, r, theta):
+        """Instantiate a spherical coordinate metric.
+
+        Parameters
+        ----------
+        r : Scalar
+            Radial coordinate
+        theta : Scalar 
+            Polar angle
+        """
+        # Even if these are scalars use as arrays
+        r = np.asarray(r)
+        theta = np.asarray(theta)
+
+        # Fill spatial metric components
+        g = np.zeros((*r.shape, 3, 3), dtype=float).view(Tensor)
+        g.yy = r**2
+        g.zz = r**2*np.sin(theta)**2
+
+        # Vanishing shift and extrinsic curvature
+        K = np.zeros_like(g)
+        beta = ThreeVector(0.0, 0.0, 0.0)
+
+        # Required time component of full metric: -alpha**2 dt**2
+        alpha = 1.0
+
+        super().__init__(g, alpha, beta, K)
+
+
+class SchwarzschildMetric(Metric):
+
+    def __init__(self, M, r, theta):
+        # Even if these are scalars use as arrays
+        r = np.asarray(r)
+        theta = np.asarray(theta)
+
+        # Schwarzschild lapse
+        alpha = np.sqrt(1.0 - 2.0*M/r)
+
+        # Vanishing shift
+        beta = np.zeros((*r.shape, 3), dtype=float).view(ThreeVector)
+
+        # Fill spatial metric components
+        g = np.zeros((*r.shape, 3, 3), dtype=float).view(Tensor)
+        g.xx = 1.0/(1.0 - 2.0*M/r)
+        g.yy = r**2
+        g.zz = r**2*np.sin(theta)**2
+
+        # Vanishing extrinsic curvature
+        K = np.zeros_like(g)
+
+        super().__init__(g, alpha, beta, K)

--- a/gr/tensor.py
+++ b/gr/tensor.py
@@ -1,0 +1,317 @@
+"""
+    tensor.py
+
+    This module implements a basic spatial three-vector and rank-two tensor.
+    These types are derived from `numpy.ndarray` for complete access to the
+    vectorized linear algebra operations in `scipy`.
+
+        * Can be created as a single vector/tensor or as a grid of vectors/
+        tensors.  This structure was chosen to facilitate vectorized
+        computations at each grid cell.
+
+        * Named properties for components are added to the `ndarray`
+        sub-classes.
+
+    Usage
+    -----
+    * Calculate the tensor-vector contraction `u_j = v_i T^ij`:
+        ```
+            v = ThreeVector(x,y,z)
+            T = Tensor.Symmetric(xx, xy, xz, yy, yz, zz)
+
+            u = T.vector_contract(v)
+        ```
+    * Calculate the tensor-vector contraction `u_i = T^ij v_j`:
+        ```
+            v = ThreeVector(x,y,z)
+            T = Tensor.Symmetric(xx, xy, xz, yy, yz, zz)
+
+            u = T.vector_contract(v, slot=1)
+        ```
+
+    * Calculate the tensor-vector-vector contraction `S = T^ij u_i v_j`:
+        ```
+            u = ThreeVector(x,y,z)
+            v = ThreeVector(x,y,z)
+            T = Tensor.Symmetric(xx, xy, xz, yy, yz, zz)
+
+            S = T.contract_with_vectors(u, v)
+        ```
+
+    * Calculate the tensor-tensor contraction `A^ik = T^i_j L^jk`:
+        ```
+            T = Tensor.Symmetric(xx, xy, xz, yy, yz, zz)
+            L = Tensor.Symmetric(xx, xy, xz, yy, yz, zz)
+
+            A = T.tensor_contract(L, slots=(1,0))
+        ```
+
+    * Calculate full tensor-tensor contraction `S = T^ij L_ij`:
+        ```
+            T = Tensor.Symmetric(xx, xy, xz, yy, yz, zz)
+            L = Tensor.Symmetric(xx, xy, xz, yy, yz, zz)
+
+            S = T.tensor_full_contract(L)
+        ```
+"""
+
+import numpy as np
+
+
+class ThreeVector(np.ndarray):
+    """Spatial 3-vector"""
+
+    def __new__(cls, x, y, z):
+        """Create a new ThreeVector.
+
+        Note
+        ----
+        `__new__` is required for deriving from `ndarray` so that casting and views work properly.
+
+        Parameters
+        ----------
+        x : Scalar
+            First component, e.g. x, r, etc.
+        y : Scalar
+            Second component, e.g. y, theta, etc.
+        z : Scalar
+            Third component, e.g. z, phi, etc.
+
+        Returns
+        -------
+        ThreeVector
+            Instantiated ThreeVector object
+        """
+        # Generally components will be stored in contiguous arrays, i.e. all
+        # `x` in one array, all `y` in a second array, etc.  This reshapes the
+        # vector to a grid of vectors (if necessary), allowing for use of
+        # `np.linalg` routines to be applied to a grid as a whole.
+        vec = np.stack([x, y, z], axis=-1).view(cls)
+
+        return vec
+
+    def __array_finalize__(self, obj):
+        """Required for deriving from `ndarray`."""
+        if obj is None:
+            return
+
+    ###################################################
+    #   Named properties for quick component access   #
+    ###################################################
+    @property
+    def x(self):
+        return self[..., 0]
+
+    @x.setter
+    def x(self, value):
+        self[..., 0] = value
+
+    @property
+    def y(self):
+        return self[..., 1]
+
+    @y.setter
+    def y(self, value):
+        self[..., 1] = value
+
+    @property
+    def z(self):
+        return self[..., 2]
+
+    @z.setter
+    def z(self, value):
+        self[..., 2] = value
+
+
+class Tensor(np.ndarray):
+    """Rank-two spatial tensor"""
+
+    # For easier selection of `einsum` parameter strings
+    _vector_contract_slots = np.array(["...ij,...i", "...ij,...j"])
+    _tensor_contract_slots = \
+        np.array([["...ij,...ik->...jk", "...ij,...ki->...jk"],
+                  ["...ij,...jk->...ik", "...ik,...jk->...ij"]])
+
+    def __new__(cls, xx, xy, xz, yx, yy, yz, zx, zy, zz):
+        """Create a new Tensor
+
+        Parameters
+        ----------
+        xx,xy,xz,yx,yy,yz,zx,zy,zz : Scalar
+            Components of the tensor
+
+        Returns
+        -------
+        Tensor
+            Instantiated Tensor object.
+        """
+        # Reshape to a grid of tensors (if needed) to facilitate `np.linalg`
+        T = np.stack([xx, xy, xz, yx, yy, yz, zx, zy, zz], axis=-1)
+        T = np.reshape(T, (*np.asarray(xx).shape, 3, 3)).view(cls)
+
+        return T
+
+    def __array_finalize__(self, obj):
+        """Required for deriving from `ndarray`."""
+        if obj is None:
+            return
+
+    @classmethod
+    def Symmetric(cls, xx, xy, xz, yy, yz, zz):
+        """Create a new symmetric Tensor
+
+        Parameters
+        ----------
+        xx,xy,xz,yy,yz,zz : Scalar
+            Components of the tensor
+
+        Returns
+        -------
+        Tensor
+            Instantiated Tensor object.
+        """
+        return cls(xx, xy, xz, xy, yy, yz, xz, yz, zz)
+
+    def vector_contract(self, A, slot=0):
+        """Contract a vector with the tensor.
+
+        Parameters
+        ----------
+        A : ThreeVector
+            Vector to contract with tensor.
+        slot : int, optional
+            Which tensor slot to contract (the default is 0, which the first
+            slot.)
+
+        Returns
+        -------
+        ThreeVector
+            3-vector resulting from contraction.
+        """
+        return np.einsum(self._vector_contract_slots[slot], self, A,
+                         optimize='greedy')
+
+    def contract_with_vectors(self, A, B):
+        """Contract two vectors with the tensor.
+
+        Parameters
+        ----------
+        A,B : ThreeVector
+            Vectors to contract with tensor.
+
+        Returns
+        -------
+        Scalar
+            Scalar resulting from contraction.
+        """
+        return np.einsum("...ij,...i,...j", self, A, B, optimize='greedy')
+
+    def tensor_contract(self, T, slots=[0, 0]):
+        """Contract a tensor with this tensor.
+
+        Parameters
+        ----------
+        T : Tensor
+            Tensor to contract with this tensor.
+        slots : (int,int), optional
+            Which tensor slots to contract (the default is (0,0), which the 
+            first slot of each tensor.)
+
+        Returns
+        -------
+        Tensor
+            Tensor resulting from contraction.
+        """
+        return np.einsum(self._tensor_contract_slots[slots], self, T,
+                         optimize='greedy')
+
+    def tensor_full_contract(self, T):
+        """Fully contract a tensor with this tensor.
+
+        Parameters
+        ----------
+        T : Tensor
+            Tensor to contract with this tensor.
+
+        Returns
+        -------
+        Scalar
+            Scalar resulting from contraction.
+        """
+        return np.einsum("...ij,...ij", self, T, optimize='greedy')
+
+    ###################################################
+    #   Named properties for quick component access   #
+    ###################################################
+
+    @property
+    def xx(self):
+        return self[..., 0, 0]
+
+    @xx.setter
+    def xx(self, value):
+        self[..., 0, 0] = value
+
+    @property
+    def xy(self):
+        return self[..., 0, 1]
+
+    @xy.setter
+    def xy(self, value):
+        self[..., 0, 1] = value
+
+    @property
+    def xz(self):
+        return self[..., 0, 2]
+
+    @xz.setter
+    def xz(self, value):
+        self[..., 0, 2] = value
+
+    @property
+    def yx(self):
+        return self[..., 1, 0]
+
+    @yx.setter
+    def yx(self, value):
+        self[..., 1, 0] = value
+
+    @property
+    def yy(self):
+        return self[..., 1, 1]
+
+    @yy.setter
+    def yy(self, value):
+        self[..., 1, 1] = value
+
+    @property
+    def yz(self):
+        return self[..., 1, 2]
+
+    @yz.setter
+    def yz(self, value):
+        self[..., 1, 2] = value
+
+    @property
+    def zx(self):
+        return self[..., 2, 0]
+
+    @zx.setter
+    def zx(self, value):
+        self[..., 2, 0] = value
+
+    @property
+    def zy(self):
+        return self[..., 2, 1]
+
+    @zy.setter
+    def zy(self, value):
+        self[..., 2, 1] = value
+
+    @property
+    def zz(self):
+        return self[..., 2, 2]
+
+    @zz.setter
+    def zz(self, value):
+        self[..., 2, 2] = value

--- a/gr/tests/test_metric.py
+++ b/gr/tests/test_metric.py
@@ -1,0 +1,97 @@
+# unit tests for the metric
+
+from gr.metric import Metric, MinkowskiMetric, SchwarzschildMetric
+from gr.tensor import ThreeVector, Tensor
+from mesh.patch import Grid1d
+
+import numpy as np
+
+from numpy.testing import assert_array_equal
+
+
+class TestMetric(object):
+    @classmethod
+    def setup_class(cls):
+        """This is run once for each class before any tests"""
+        pass
+
+    @classmethod
+    def teardown_class(cls):
+        """This is run once for each class after any tests"""
+        pass
+
+    def setup_method(self):
+        """This is run before each test"""
+        self.M = 1.0
+        self.R = 2.0*self.M
+        self.grid = Grid1d(10, xmin=1.5*self.R, xmax=2.0*self.R)
+
+    def teardown_method(self):
+        """This is run after each test"""
+        self.M = None
+        self.R = None
+        self.grid = None
+
+    def test_create_minkowski(self):
+        """Test creating a Minkowski metric"""
+        metric = MinkowskiMetric()
+
+        eta = np.eye(3).view(Tensor)
+
+        assert np.allclose(metric.g, eta)
+        assert np.allclose(metric.inv_g, eta)
+        assert np.allclose(metric.det_g, 1.0)
+
+        assert np.allclose(metric.K, 0.0)
+        assert np.allclose(metric.beta, 0.0)
+        assert np.allclose(metric.alpha, 1.0)
+
+    def test_raise_lower_vector(self):
+        """Test creating and using a Schwarzschild metric to raise/lower 
+        vector indices."""
+        r = self.grid.x
+
+        metric = SchwarzschildMetric(self.M, r, 0.5*np.pi)
+
+        a2 = 1.0-2.0*self.M/r
+
+        # x = 0.0*r + 1.0
+        x = 1.0
+        y = 2.0*x
+        z = 3.0*x
+
+        A = ThreeVector(x, y, z)
+
+        Au = metric.raise_vector(A)
+        Al = metric.lower_vector(Au)
+
+        actual_Au = ThreeVector(x*a2, y/(r**2), z/(r**2))
+
+        assert np.allclose(Au, actual_Au)
+        assert np.allclose(Al, A)
+
+    def test_raise_lower_tensor(self):
+        """Test creating and using a Schwarzschild metric to raise/lower 
+        tensor indices."""
+
+        r = self.grid.x
+
+        metric = SchwarzschildMetric(self.M, r, 0.5*np.pi)
+
+        a2 = 1.0-2.0*self.M/r
+
+        # x = np.ones(self.grid.qx)
+        x = 1.0
+        y = 2.0*x
+        z = 3.0*x
+        zs = np.zeros(self.grid.qx)
+
+        T = Tensor.Symmetric(x, 0.0, 0.0, y, 0.0, z)
+
+        Tuu = metric.raise_tensor_all(T)
+        Tll = metric.lower_tensor_all(Tuu)
+
+        actual_Tuu = Tensor.Symmetric(x*a2*a2, zs, zs, y/(r**4), zs, z/(r**4))
+
+        assert np.allclose(Tuu, actual_Tuu)
+        assert np.allclose(Tll, T)

--- a/mesh/array_indexer.py
+++ b/mesh/array_indexer.py
@@ -25,6 +25,19 @@ def _buf_split(b):
     return bxlo, bxhi, bylo, byhi
 
 
+def _buf_split_1d(b):
+    """ take an integer or iterable and break it into a -x, +x,
+    value representing a ghost cell buffer
+    """
+    try:
+        blo, bhi = b
+    except (ValueError, TypeError):
+        blo = b
+        bhi = b
+
+    return blo, bhi
+
+
 class ArrayIndexer(np.ndarray):
     """ a class that wraps the data region of a single array (d)
         and allows us to easily do array operations like d[i+1,j]
@@ -325,6 +338,218 @@ class ArrayIndexer(np.ndarray):
         leg = """
          ^ y
          |
+         +---> x
+        """
+        print(leg)
+
+
+class ArrayIndexer1d(np.ndarray):
+    """ a class that wraps the data region of a single array 1d (d)
+        and allows us to easily do array operations like d[i+1,j]
+        using the ip() method. """
+
+    def __new__(self, d, grid=None):
+        obj = np.asarray(d).view(self)
+        obj.g = grid
+        obj.c = len(d.shape)
+
+        return obj
+
+    def __array_finalize__(self, obj):
+        if obj is None:
+            return
+        self.g = getattr(obj, "g", None)
+        self.c = getattr(obj, "c", None)
+
+    def __array_wrap__(self, out_arr, context=None):
+        return np.ndarray.__array_wrap__(self, out_arr, context)
+
+    def v(self, buf=0, n=0, s=1):
+        """return a view of the valid data region for component n, with stride
+        s, and a buffer of ghost cells given by buf
+
+        """
+        return self.ip(0, buf=buf, n=n, s=s)
+
+    def ip(self, ishift, buf=0, n=0, s=1):
+        """return a view of the data shifted by ishift in the x direction.  By 
+        default the view is the same size as the valid region, but the buf can 
+        specify how many ghost cells on each side to include.  The component 
+        is n and s is the stride
+        """
+        bxlo, bxhi = _buf_split_1d(buf)
+        c = len(self.shape)
+
+        if c == 1:
+            return np.asarray(self[self.g.ilo-bxlo+ishift:self.g.ihi+1+bxhi+ishift:s])
+        else:
+            return np.asarray(self[self.g.ilo-bxlo+ishift:self.g.ihi+1+bxhi+ishift:s, n])
+
+    def lap(self, n=0, buf=0):
+        """return the 3-point Laplacian"""
+        l = (self.ip(-1, n=n, buf=buf) - 2*self.v(n=n, buf=buf) + self.ip(1, n=n, buf=buf))/self.g.dx**2
+        return l
+
+    def norm(self, n=0):
+        """
+        find the norm of the quantity (index n) defined on the same grid,
+        in the domain's valid region
+
+        """
+        c = len(self.shape)
+        if c == 1:
+            return np.sqrt(self.g.dx *
+                           np.sum((self[self.g.ilo:self.g.ihi+1]**2).flat))
+
+        else:
+            _tmp = self[:, :, n]
+            return np.sqrt(self.g.dx *
+                           np.sum((_tmp[self.g.ilo:self.g.ihi+1]**2).flat))
+
+    def copy(self):
+        """make a copy of the array, defined on the same grid"""
+        return ArrayIndexer1d(np.asarray(self).copy(), grid=self.g)
+
+    def is_symmetric(self, nodal=False, tol=1.e-14, asymmetric=False):
+        """return True is the data is left-right symmetric (to the tolerance
+        tol) For node-centered data, set nodal=True
+
+        """
+
+        # prefactor to convert from symmetric to asymmetric test
+        s = 1
+        if asymmetric:
+            s = -1
+
+        if not nodal:
+            L = self[self.g.ilo:self.g.ilo+self.g.nx//2]
+            R = self[self.g.ilo+self.g.nx//2:self.g.ihi+1]
+        else:
+            L = self[self.g.ilo:self.g.ilo+self.g.nx//2+1]
+            R = self[self.g.ilo+self.g.nx//2:self.g.ihi+2]
+
+        e = abs(L - s*R[::-1]).max()
+        return e < tol
+
+    def is_asymmetric(self, nodal=False, tol=1.e-14):
+        """return True is the data is left-right asymmetric (to the tolerance
+        tol)---e.g, the sign flips. For node-centered data, set nodal=True
+
+        """
+        return self.is_symmetric(nodal=nodal, tol=tol, asymmetric=True)
+
+    def fill_ghost(self, n=0, bc=None):
+        """Fill the boundary conditions.  This operates on a single component,
+        n. We do periodic, reflect-even, reflect-odd, and outflow
+
+        We need a BC object to tell us what BC type on each boundary.
+        """
+
+        # there is only a single grid, so every boundary is on
+        # a physical boundary (except if we are periodic)
+
+        # Note: we piggy-back on outflow and reflect-odd for
+        # Neumann and Dirichlet homogeneous BCs respectively, but
+        # this only works for a single ghost cell
+
+        # -x boundary
+        if bc.xlb in ["outflow", "neumann"]:
+            if bc.xl_value is None:
+                for i in range(self.g.ilo):
+                    self[i, n] = self[self.g.ilo, n]
+            else:
+                self[self.g.ilo-1, n] = \
+                    self[self.g.ilo, n] - self.g.dx*bc.xl_value
+
+        elif bc.xlb == "reflect-even":
+            for i in range(self.g.ilo):
+                self[i, n] = self[2*self.g.ng-i-1, n]
+
+        elif bc.xlb in ["reflect-odd", "dirichlet"]:
+            if bc.xl_value is None:
+                for i in range(self.g.ilo):
+                    self[i, n] = -self[2*self.g.ng-i-1, n]
+            else:
+                self[self.g.ilo-1, n] = \
+                    2*bc.xl_value - self[self.g.ilo, n]
+
+        elif bc.xlb == "periodic":
+            for i in range(self.g.ilo):
+                self[i, n] = self[self.g.ihi-self.g.ng+i+1, n]
+
+        # +x boundary
+        if bc.xrb in ["outflow", "neumann"]:
+            if bc.xr_value is None:
+                for i in range(self.g.ihi+1, self.g.nx+2*self.g.ng):
+                    self[i, n] = self[self.g.ihi, n]
+            else:
+                self[self.g.ihi+1, n] = \
+                    self[self.g.ihi, n] + self.g.dx*bc.xr_value
+
+        elif bc.xrb == "reflect-even":
+            for i in range(self.g.ng):
+                i_bnd = self.g.ihi+1+i
+                i_src = self.g.ihi-i
+
+                self[i_bnd, n] = self[i_src, n]
+
+        elif bc.xrb in ["reflect-odd", "dirichlet"]:
+            if bc.xr_value is None:
+                for i in range(self.g.ng):
+                    i_bnd = self.g.ihi+1+i
+                    i_src = self.g.ihi-i
+
+                    self[i_bnd, n] = -self[i_src, n]
+            else:
+                self[self.g.ihi+1, n] = \
+                    2*bc.xr_value - self[self.g.ihi, n]
+
+        elif bc.xrb == "periodic":
+            for i in range(self.g.ihi+1, 2*self.g.ng + self.g.nx):
+                self[i, n] = self[i-self.g.ihi-1+self.g.ng, n]
+
+    def pretty_print(self, n=0, fmt=None, show_ghost=True):
+        """
+        Print out a small dataset to the screen with the ghost cells
+        a different color, to make things stand out
+        """
+
+        if fmt is None:
+            if self.dtype == np.int:
+                fmt = "%4d"
+            elif self.dtype == np.float64:
+                fmt = "%10.5g"
+            else:
+                raise ValueError("ERROR: dtype not supported")
+
+        # print j descending, so it looks like a grid (y increasing
+        # with height)
+        if show_ghost:
+            ilo = 0
+            ihi = self.g.qx-1
+
+        else:
+            ilo = self.g.ilo
+            ihi = self.g.ihi
+
+        for i in range(ilo, ihi+1):
+
+            if (i < self.g.ilo) or (i > self.g.ihi):
+                gc = 1
+            else:
+                gc = 0
+
+            if self.c == 1:
+                val = self[i]
+            else:
+                val = self[i, n]
+
+            if gc:
+                print("\033[31m" + fmt % (val) + "\033[0m", end="")
+            else:
+                print(fmt % (val), end="")
+
+        leg = """
          +---> x
         """
         print(leg)

--- a/mesh/tests/test_array_indexer.py
+++ b/mesh/tests/test_array_indexer.py
@@ -11,6 +11,11 @@ def test_buf_split():
     assert_array_equal(ai._buf_split((2, 3)), [2, 3, 2, 3])
 
 
+def test_buf_split_1d():
+    assert_array_equal(ai._buf_split_1d(2), [2, 2])
+    assert_array_equal(ai._buf_split_1d((2, 3)), [2, 3])
+
+
 # ArrayIndexer tests
 def test_indexer():
     g = patch.Grid2d(2, 3, ng=2)
@@ -47,5 +52,36 @@ def test_is_asymmetric():
     a[:, 0] = [-1, -2, 2, 1]
     a[:, 1] = [-2, -4, 4, 2]
     a[:, 2] = [-1, -2, 2, 1]
+
+    assert a.is_asymmetric()
+
+
+# ArrayIndexer1d tests
+def test_indexer_1d():
+    g = patch.Grid1d(3, ng=2)
+    a = g.scratch_array()
+
+    a[:] = np.arange(g.qx)
+
+    assert_array_equal(a.v(), np.array([2., 3., 4.]))
+
+    assert_array_equal(a.ip(1), np.array([3., 4., 5.]))
+    assert_array_equal(a.ip(-1), np.array([1., 2., 3.]))
+
+
+def test_is_symmetric_1d():
+    g = patch.Grid1d(4, ng=0)
+    a = g.scratch_array()
+
+    a[:] = [1, 2, 2, 1]
+
+    assert a.is_symmetric()
+
+
+def test_is_asymmetric_1d():
+    g = patch.Grid1d(4, ng=0)
+    a = g.scratch_array()
+
+    a[:] = [-1, -2, 2, 1]
 
     assert a.is_asymmetric()

--- a/mesh/tests/test_io.py
+++ b/mesh/tests/test_io.py
@@ -28,3 +28,26 @@ def test_write_read():
     anew = nd.get_var("a")
 
     assert_array_equal(anew.v(), a.v())
+
+
+def test_write_read_1d():
+
+    myg = patch.Grid1d(8, ng=2, xmax=1.0)
+    myd = patch.CellCenterData1d(myg)
+
+    bco = bnd.BC(xlb="outflow", xrb="outflow")
+    myd.register_var("a", bco)
+
+    myd.create()
+
+    a = myd.get_var("a")
+    a.v()[:] = np.arange(8)
+
+    myd.write("io_test_1d")
+
+    # now read it in
+    nd = io.read_1d("io_test_1d")
+
+    anew = nd.get_var("a")
+
+    assert_array_equal(anew.v(), a.v())

--- a/util/io.py
+++ b/util/io.py
@@ -120,3 +120,100 @@ def read(filename):
         return sim
 
     return myd
+
+
+def read_1d(filename):
+    """read an HDF5 file and recreate the simulation object that holds the
+    data and state of the simulation.
+
+    """
+    if not filename.endswith(".h5"):
+        filename += ".h5"
+
+    with h5py.File(filename, "r") as f:
+
+        # read the simulation information -- this only exists if the
+        # file was created as a simulation object
+        try:
+            solver_name = f.attrs["solver"]
+            problem_name = f.attrs["problem"]
+            t = f.attrs["time"]
+            n = f.attrs["nsteps"]
+        except KeyError:
+            # this was just a patch written out
+            solver_name = None
+
+        # read in the grid info and create our grid
+        grid = f["grid"].attrs
+
+        myg = patch.Grid1d(grid["nx"], ng=grid["ng"],
+                           xmin=grid["xmin"], xmax=grid["xmax"])
+
+        # sometimes problems define custom BCs -- at the moment, we
+        # are going to assume that these always map to BC.user.  We
+        # need to read these in now, since the variable creation
+        # requires it.
+        custom_bcs = read_bcs(f)
+        if custom_bcs is not None:
+            if solver_name in ["compressible_fv4", "compressible_rk", "compressible_sdc"]:
+                bc_solver = "compressible"
+            else:
+                bc_solver = solver_name
+            bcmod = importlib.import_module("{}.{}".format(bc_solver, "BC"))
+            for name in custom_bcs:
+                bnd.define_bc(name, bcmod.user, is_solid=custom_bcs[name])
+
+        # read in the variable info -- start by getting the names
+        gs = f["state"]
+        names = []
+        for n in gs:
+            names.append(n)
+
+        # create the CellCenterData1d object
+        myd = patch.CellCenterData1d(myg)
+
+        for n in names:
+            grp = gs[n]
+            bc = bnd.BC1d(xlb=grp.attrs["xlb"], xrb=grp.attrs["xrb"])
+            myd.register_var(n, bc)
+
+        myd.create()
+
+        # auxillary data
+        for k in f["aux"].attrs:
+            myd.set_aux(k, f["aux"].attrs[k])
+
+        # restore the variable data
+        for n in names:
+            grp = gs[n]
+            data = grp["data"]
+
+            v = myd.get_var(n)
+            v.v()[:] = data[:]
+
+        # restore the particle data
+        try:
+            gparticles = f["particles"]
+            particle_data = gparticles["particle_positions"]
+            init_data = gparticles["init_particle_positions"]
+
+            my_particles = particles.Particles(myd, None, len(particle_data),
+                                            "array", particle_data, init_data)
+        except KeyError:
+            my_particles = None
+
+        if solver_name is not None:
+            solver = importlib.import_module(solver_name)
+
+            sim = solver.Simulation(solver_name, problem_name, None)
+            sim.n = n
+            sim.cc_data = myd
+            sim.cc_data.t = t
+            sim.particles = my_particles
+
+            sim.read_extras(f)
+
+    if solver_name is not None:
+        return sim
+
+    return myd


### PR DESCRIPTION
Implementation of a 3+1 split metric interface (can also be derived from for 1+1 and 2+1), and sample implementations of Minkowski and Schwarzschild metrics.  Also included are sub-classed `numpy.ndarray` three-vector and rank-two tensor objects; additional routines to facilitate contractions and named component accesses are included.

Additionally, I added support for 1D meshing (previously `pryo` only included 2D meshing and "1D" problems were simulated by only considering one axis).  The new 1D specific meshing will help reduce memory usage and _should_ run faster than the 2D counterparts.  Further testing will be needed, e.g. a simple 1D non-relativistic shock tube.

All new features also include unit tests.  Easiest way to run these is:
```bash
./test.py -u
```
from the top-level `pyro` directory; the `-u` flag specifies to run only unit tests and not the more costly solver tests.